### PR TITLE
Include path for NVML on RHEL

### DIFF
--- a/deployments/helm/k8s-dra-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/k8s-dra-driver/templates/kubeletplugin.yaml
@@ -69,7 +69,7 @@ spec:
         - name: NVIDIA_MIG_CONFIG_DEVICES
           value: all
         - name: LD_LIBRARY_PATH
-          value: /usr/lib64/:/run/nvidia/driver/usr/lib/x86_64-linux-gnu
+          value: /usr/lib64/:/run/nvidia/driver/usr/lib/x86_64-linux-gnu:/run/nvidia/driver/usr/lib64/
         - name: NODE_NAME
           valueFrom:
             fieldRef:
@@ -91,7 +91,7 @@ spec:
           readOnly: true
         lifecycle:
           preStop:
-            exec: 
+            exec:
               command: ["set-nas-status", "--status", "NotReady"]
       volumes:
       - name: plugins-registry


### PR DESCRIPTION
Fix the kubelet-plugin pod crashing on OpenShift (RHCOS/RHEL) because it cannot find `libnvidia-ml.so` in the path.

Fixes #4 