### PR TITLE
Address issues with running DRA driver on GKE

### DIFF
--- a/cmd/nvidia-dra-plugin/cdi.go
+++ b/cmd/nvidia-dra-plugin/cdi.go
@@ -50,6 +50,7 @@ type CDIHandler struct {
 	nvcdi            nvcdi.Interface
 	registry         cdiapi.Registry
 	driverRoot       string
+	devRoot          string
 	targetDriverRoot string
 	nvidiaCTKPath    string
 
@@ -84,6 +85,7 @@ func NewCDIHandler(opts ...cdiOption) (*CDIHandler, error) {
 		nvcdilib, err := nvcdi.New(
 			nvcdi.WithDeviceLib(h.nvdevice),
 			nvcdi.WithDriverRoot(h.driverRoot),
+			nvcdi.WithDevRoot(h.devRoot),
 			nvcdi.WithLogger(h.logger),
 			nvcdi.WithNvmlLib(h.nvml),
 			nvcdi.WithMode("nvml"),

--- a/cmd/nvidia-dra-plugin/find.go
+++ b/cmd/nvidia-dra-plugin/find.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 )
 
@@ -58,6 +59,25 @@ func (r root) getNvidiaSMIPath() (string, error) {
 	}
 
 	return binaryPath, nil
+}
+
+// isDevRoot checks whether the specified root is a dev root.
+// A dev root is defined as a root containing a /dev folder.
+func (r root) isDevRoot() bool {
+	stat, err := os.Stat(filepath.Join(string(r), "dev"))
+	if err != nil {
+		return false
+	}
+	return stat.IsDir()
+}
+
+// getDevRoot returns the dev root associated with the root.
+// If the root is not a dev root, this defaults to "/".
+func (r root) getDevRoot() string {
+	if r.isDevRoot() {
+		return string(r)
+	}
+	return "/"
 }
 
 // findFile searches the root for a specified file.

--- a/cmd/nvidia-dra-plugin/options.go
+++ b/cmd/nvidia-dra-plugin/options.go
@@ -31,6 +31,13 @@ func WithDriverRoot(root string) cdiOption {
 	}
 }
 
+// WithDevRoot provides a cdiOption to set the device root used by the 'cdi' interface.
+func WithDevRoot(root string) cdiOption {
+	return func(c *CDIHandler) {
+		c.devRoot = root
+	}
+}
+
 // WithTargetDriverRoot provides an cdiOption to set the target driver root used by the 'cdi' interface.
 func WithTargetDriverRoot(root string) cdiOption {
 	return func(c *CDIHandler) {

--- a/demo/clusters/gke/create-cluster.sh
+++ b/demo/clusters/gke/create-cluster.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+# Copyright 2023 NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+: ${PROJECT_NAME:=$(gcloud config list --format 'value(core.project)' 2>/dev/null)}
+
+if [[ -z ${PROJECT_NAME} ]]; then
+	echo "Project name could not be determined"
+	echo "Please run 'gcloud config set project'"
+	exit 1
+fi
+
+CURRENT_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+PROJECT_DIR="$(cd -- "$( dirname -- "${CURRENT_DIR}/../../../.." )" &> /dev/null && pwd)"
+
+# We extract information from versions.mk
+function from_versions_mk() {
+    local makevar=$1
+    local value=$(grep -E "^\s*${makevar}\s+[\?:]= " ${PROJECT_DIR}/versions.mk)
+    echo ${value##*= }
+}
+DRIVER_NAME=$(from_versions_mk "DRIVER_NAME")
+
+NETWORK_NAME="${DRIVER_NAME}-net"
+CLUSTER_NAME="${DRIVER_NAME}-cluster"
+
+## Create the Network for the cluster
+gcloud compute networks create "${NETWORK_NAME}" \
+	--quiet \
+	--project="${PROJECT_NAME}" \
+	--description=Manually\ created\ network\ for\ TMS\ DRA\ Alpha\ cluster \
+	--subnet-mode=auto \
+	--mtu=1460 \
+	--bgp-routing-mode=regional
+
+## Create the cluster
+gcloud container clusters create "${CLUSTER_NAME}" \
+	--quiet \
+	--enable-kubernetes-alpha \
+	--no-enable-autorepair \
+	--no-enable-autoupgrade \
+	--region us-west1 \
+	--network "${NETWORK_NAME}" \
+	--node-labels=nvidia.com/dra.controller=true
+
+# Create t4 node pool
+gcloud beta container node-pools create "pool-1" \
+	--quiet \
+	--project "${PROJECT_NAME}" \
+	--cluster "${CLUSTER_NAME}" \
+	--region "us-west1" \
+	--node-version "1.27.3-gke.100" \
+	--machine-type "n1-standard-8" \
+	--accelerator "type=nvidia-tesla-t4,count=1" \
+	--image-type "UBUNTU_CONTAINERD" \
+	--disk-type "pd-standard" \
+	--disk-size "100" \
+	--metadata disable-legacy-endpoints=true \
+	--scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
+	--num-nodes "2" \
+	--enable-autoscaling \
+	--min-nodes "2" \
+	--max-nodes "6" \
+	--location-policy "ANY" \
+	--no-enable-autoupgrade \
+	--no-enable-autorepair \
+	--max-surge-upgrade 1 \
+	--max-unavailable-upgrade 0 \
+	--node-locations "us-west1-a" \
+	--node-labels=gke-no-default-nvidia-gpu-device-plugin=true,nvidia.com/gpu=present,nvidia.com/dra.kubelet-plugin=true
+
+# Create v100 node pool
+gcloud beta container node-pools create "pool-2" \
+	--quiet \
+    --project "${PROJECT_NAME}" \
+	--cluster "${CLUSTER_NAME}" \
+	--region "us-west1" \
+	--node-version "1.27.3-gke.100" \
+	--machine-type "n1-standard-8" \
+	--accelerator "type=nvidia-tesla-v100,count=1" \
+	--image-type "UBUNTU_CONTAINERD" \
+	--disk-type "pd-standard" \
+	--disk-size "100" \
+	--metadata disable-legacy-endpoints=true \
+	--scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
+	--num-nodes "1" \
+	--enable-autoscaling \
+	--min-nodes "1" \
+	--max-nodes "6" \
+	--location-policy "ANY" \
+	--no-enable-autoupgrade \
+	--no-enable-autorepair \
+	--max-surge-upgrade 1 \
+	--max-unavailable-upgrade 0 \
+	--node-locations "us-west1-a" \
+	--node-labels=gke-no-default-nvidia-gpu-device-plugin=true,nvidia.com/gpu=present,nvidia.com/dra.kubelet-plugin=true
+
+## Allow the GPU nodes access to the internet
+gcloud compute routers create ${NETWORK_NAME}-nat-router \
+	--quiet \
+	--project "${PROJECT_NAME}" \
+	--network "${NETWORK_NAME}" \
+	--region "us-west1"
+
+gcloud compute routers nats create "${NETWORK_NAME}-nat-config" \
+	--quiet \
+	--project "${PROJECT_NAME}" \
+    --router "${NETWORK_NAME}-nat-router" \
+    --nat-all-subnet-ip-ranges \
+    --auto-allocate-nat-external-ips \
+    --router-region "us-west1"
+
+## Start using this cluster for kubectl
+gcloud container clusters get-credentials "${CLUSTER_NAME}" --location="us-west1"
+
+## Launch the nvidia-driver-installer daemonset to install the GPU drivers on any GPU nodes that come online:
+kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/ubuntu/daemonset-preloaded.yaml
+
+## Create the nvidia namespace
+kubectl create namespace nvidia
+
+## Deploy a custom daemonset that prepares a node for use with DRA
+kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-dra-driver/456d097feb452cca1351817bab2ccd0782e96c9f/demo/prepare-gke-nodes-for-dra.yaml

--- a/demo/clusters/gke/delete-cluster.sh
+++ b/demo/clusters/gke/delete-cluster.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright 2023 NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+: ${PROJECT_NAME:=$(gcloud config list --format 'value(core.project)' 2>/dev/null)}
+
+CURRENT_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+PROJECT_DIR="$(cd -- "$( dirname -- "${CURRENT_DIR}/../../../.." )" &> /dev/null && pwd)"
+
+# We extract information from versions.mk
+function from_versions_mk() {
+    local makevar=$1
+    local value=$(grep -E "^\s*${makevar}\s+[\?:]= " ${PROJECT_DIR}/versions.mk)
+    echo ${value##*= }
+}
+DRIVER_NAME=$(from_versions_mk "DRIVER_NAME")
+
+NETWORK_NAME="${DRIVER_NAME}-net"
+CLUSTER_NAME="${DRIVER_NAME}-cluster"
+
+## Delete the cluster
+gcloud container clusters delete "${CLUSTER_NAME}" \
+	--quiet \
+	--project "${PROJECT_NAME}" \
+	--region "us-west1"
+
+## Delete the nat config
+gcloud compute routers nats delete "${NETWORK_NAME}-nat-config" \
+	--quiet \
+	--project "${PROJECT_NAME}" \
+    --router "${NETWORK_NAME}-nat-router" \
+    --router-region "us-west1"
+
+## Delete the nat router
+gcloud compute routers delete ${NETWORK_NAME}-nat-router \
+	--quiet \
+	--project "${PROJECT_NAME}" \
+	--region "us-west1"
+
+## Delete the network
+gcloud compute networks delete "${NETWORK_NAME}" \
+	--quiet \
+	--project "${PROJECT_NAME}"

--- a/demo/clusters/gke/install-dra-driver.sh
+++ b/demo/clusters/gke/install-dra-driver.sh
@@ -27,7 +27,7 @@ DRIVER_NAME=$(from_versions_mk "DRIVER_NAME")
 
 : ${IMAGE_REGISTRY:=registry.gitlab.com/nvidia/cloud-native/k8s-dra-driver/staging}
 : ${IMAGE_NAME:=${DRIVER_NAME}}
-: ${IMAGE_TAG:=f2e6e89c-ubuntu20.04}
+: ${IMAGE_TAG:=530b16c-ubuntu20.04}
 
 helm upgrade -i --create-namespace --namespace nvidia nvidia-dra-driver ${PROJECT_DIR}/deployments/helm/k8s-dra-driver \
   --set image.repository=${IMAGE_REGISTRY}/${IMAGE_NAME} \

--- a/demo/clusters/gke/install-dra-driver.sh
+++ b/demo/clusters/gke/install-dra-driver.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright 2023 NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CURRENT_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+PROJECT_DIR="$(cd -- "$( dirname -- "${CURRENT_DIR}/../../../.." )" &> /dev/null && pwd)"
+
+# We extract information from versions.mk
+function from_versions_mk() {
+    local makevar=$1
+    local value=$(grep -E "^\s*${makevar}\s+[\?:]= " ${PROJECT_DIR}/versions.mk)
+    echo ${value##*= }
+}
+DRIVER_NAME=$(from_versions_mk "DRIVER_NAME")
+
+: ${IMAGE_REGISTRY:=registry.gitlab.com/nvidia/cloud-native/k8s-dra-driver/staging}
+: ${IMAGE_NAME:=${DRIVER_NAME}}
+: ${IMAGE_TAG:=f2e6e89c-ubuntu20.04}
+
+helm upgrade -i --create-namespace --namespace nvidia nvidia-dra-driver ${PROJECT_DIR}/deployments/helm/k8s-dra-driver \
+  --set image.repository=${IMAGE_REGISTRY}/${IMAGE_NAME} \
+  --set image.tag=${IMAGE_TAG} \
+  --set image.pullPolicy=Always \
+  --set controller.priorityClassName="" \
+  --set kubeletPlugin.priorityClassName="" \
+  --set nvidiaDriverRoot="/opt/nvidia" \
+  --set kubeletPlugin.tolerations[0].key=nvidia.com/gpu \
+  --set kubeletPlugin.tolerations[0].operator=Exists \
+  --set kubeletPlugin.tolerations[0].effect=NoSchedule

--- a/demo/specs/selectors/README.md
+++ b/demo/specs/selectors/README.md
@@ -1,0 +1,48 @@
+#### List the set of nodes in the cluster
+```console
+kubectl get nodes -A
+```
+
+#### Show the set of nodes which have GPUs available
+```console
+kubectl get nodeallocationstates.nas.gpu.resource.nvidia.com -A
+```
+
+#### Show the set of allocatable GPUs from each node
+```console
+kubectl get nodeallocationstates.nas.gpu.resource.nvidia.com -A -o=json \
+	| jq -r '.items[] 
+             | "\(.metadata.name):",
+             (.spec.allocatableDevices[])'
+```
+
+### Open the yaml files with the specs for the demo
+```console
+vi -O parameters.yaml claims.yaml pods.yaml
+```
+
+#### Create a namespace for the demo and deploy the demo pods
+```console
+kubectl create namespace kubecon-demo
+kubectl apply -f parameters.yaml -f claims.yaml -f pods.yaml
+```
+
+#### Show the pods running
+```console
+kubectl get pod -n kubecon-demo
+```
+
+#### Show the set of GPUs allocated to some claim
+```console
+kubectl get nodeallocationstates.nas.gpu.resource.nvidia.com -A -o=json \
+	| jq -r '.items[]
+             | select(.spec.allocatedClaims)
+             | "\(.metadata.name):",
+             (.spec.allocatedClaims[])'
+```
+
+#### Show the logs of the inference and training pods
+```console
+kubectl logs -n kubecon-demo inference-pod
+kubectl logs -n kubecon-demo training-pod
+```

--- a/demo/specs/selectors/claims.yaml
+++ b/demo/specs/selectors/claims.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: resource.k8s.io/v1alpha2
+kind: ResourceClaimTemplate
+metadata:
+  namespace: kubecon-demo
+  name: "inference-gpu"
+spec:
+  spec:
+    resourceClassName: gpu.nvidia.com
+    parametersRef:
+      apiGroup: gpu.resource.nvidia.com
+      kind: GpuClaimParameters
+      name: "inference-gpu"
+
+---
+apiVersion: resource.k8s.io/v1alpha2
+kind: ResourceClaimTemplate
+metadata:
+  namespace: kubecon-demo
+  name: "training-gpu"
+spec:
+  spec:
+    resourceClassName: gpu.nvidia.com
+    parametersRef:
+      apiGroup: gpu.resource.nvidia.com
+      kind: GpuClaimParameters
+      name: "training-gpu"

--- a/demo/specs/selectors/parameters.yaml
+++ b/demo/specs/selectors/parameters.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: gpu.resource.nvidia.com/v1alpha1
+kind: GpuClaimParameters
+metadata:
+  namespace: kubecon-demo
+  name: "inference-gpu"
+spec:
+  selector:
+    andExpression:
+    - memory:
+        value: "16G"
+        operator: LessThanOrEqualTo
+    - cudaComputeCapability:
+        value: "7.5"
+        operator: GreaterThanOrEqualTo
+
+---
+apiVersion: gpu.resource.nvidia.com/v1alpha1
+kind: GpuClaimParameters
+metadata:
+  namespace: kubecon-demo
+  name: "training-gpu"
+spec:
+  selector:
+    memory:
+      value: "16G"
+      operator: GreaterThanOrEqualTo
+

--- a/demo/specs/selectors/pods.yaml
+++ b/demo/specs/selectors/pods.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: kubecon-demo
+  name: "inference-pod"
+  labels:
+    app: inference-pod
+spec:
+  resourceClaims:
+  - name: gpu
+    source:
+      resourceClaimTemplateName: "inference-gpu"
+  containers:
+  - name: ctr
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; sleep 9999"]
+    resources:
+      claims:
+      - name: gpu
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: kubecon-demo
+  name: "training-pod"
+  labels:
+    app: training-pod
+spec:
+  resourceClaims:
+  - name: gpu
+    source:
+      resourceClaimTemplateName: "training-gpu"
+  containers:
+  - name: ctr
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; sleep 9999"]
+    resources:
+      claims:
+      - name: gpu
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule

--- a/deployments/container/Dockerfile.ubi8
+++ b/deployments/container/Dockerfile.ubi8
@@ -42,6 +42,7 @@ LABEL com.nvidia.git-commit="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="NVIDIA DRA driver for Kubernetes"
 LABEL description="See summary"
+LABEL org.opencontainers.image.description "NVIDIA GPU DRA driver for Kubernetes"
 
 RUN mkdir /licenses && mv /NGC-DL-CONTAINER-LICENSE /licenses/NGC-DL-CONTAINER-LICENSE
 

--- a/deployments/container/Dockerfile.ubuntu
+++ b/deployments/container/Dockerfile.ubuntu
@@ -42,6 +42,7 @@ LABEL com.nvidia.git-commit="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="NVIDIA DRA driver for Kubernetes"
 LABEL description="See summary"
+LABEL org.opencontainers.image.description "NVIDIA GPU DRA driver for Kubernetes"
 
 RUN mkdir /licenses && mv /NGC-DL-CONTAINER-LICENSE /licenses/NGC-DL-CONTAINER-LICENSE
 

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ replace (
 require (
 	github.com/NVIDIA/go-nvlib v0.0.0-20231116150931-9fd385bace0d
 	github.com/NVIDIA/go-nvml v0.12.0-1.0.20231020145430-e06766c5e74f
-	github.com/NVIDIA/nvidia-container-toolkit v1.14.4-0.20231120112525-f6e3593a726a
+	github.com/NVIDIA/nvidia-container-toolkit v1.14.4-0.20231120225202-039d7fd32429
 	github.com/prometheus/client_golang v1.14.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/NVIDIA/go-nvlib v0.0.0-20231116150931-9fd385bace0d h1:XxRHS7eNkZVcPpZ
 github.com/NVIDIA/go-nvlib v0.0.0-20231116150931-9fd385bace0d/go.mod h1:HPFNPAYqQeoos58MKUboWsdZMu71EzSQrbmd+QBRD40=
 github.com/NVIDIA/go-nvml v0.12.0-1.0.20231020145430-e06766c5e74f h1:FTblgO87K1vPB8tcwM5EOFpFf6UpsrlDpErPm25mFWE=
 github.com/NVIDIA/go-nvml v0.12.0-1.0.20231020145430-e06766c5e74f/go.mod h1:7ruy85eOM73muOc/I37euONSwEyFqZsv5ED9AogD4G0=
-github.com/NVIDIA/nvidia-container-toolkit v1.14.4-0.20231120112525-f6e3593a726a h1:WCIh4hzRaFh0/A/FZsHgz4uAz6sxqt0njZfU+HUGG8s=
-github.com/NVIDIA/nvidia-container-toolkit v1.14.4-0.20231120112525-f6e3593a726a/go.mod h1:yd+UnaIUSX3vjLVfewaDQ+R7XrgG38+hMZZXrygK3w0=
+github.com/NVIDIA/nvidia-container-toolkit v1.14.4-0.20231120225202-039d7fd32429 h1:+iGAHhhsREKFiJb1A+txLMVi3oPAoNC2kH8AtQsbzRc=
+github.com/NVIDIA/nvidia-container-toolkit v1.14.4-0.20231120225202-039d7fd32429/go.mod h1:yd+UnaIUSX3vjLVfewaDQ+R7XrgG38+hMZZXrygK3w0=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/char_devices.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/char_devices.go
@@ -27,20 +27,13 @@ type charDevices mounts
 var _ Discover = (*charDevices)(nil)
 
 // NewCharDeviceDiscoverer creates a discoverer which locates the specified set of device nodes.
-func NewCharDeviceDiscoverer(logger logger.Interface, devices []string, root string) Discover {
+func NewCharDeviceDiscoverer(logger logger.Interface, devRoot string, devices []string) Discover {
 	locator := lookup.NewCharDeviceLocator(
 		lookup.WithLogger(logger),
-		lookup.WithRoot(root),
+		lookup.WithRoot(devRoot),
 	)
 
-	return NewDeviceDiscoverer(logger, locator, root, devices)
-}
-
-// NewDeviceDiscoverer creates a discoverer which locates the specified set of device nodes using the specified locator.
-func NewDeviceDiscoverer(logger logger.Interface, locator lookup.Locator, root string, devices []string) Discover {
-	m := NewMounts(logger, locator, root, devices).(*mounts)
-
-	return (*charDevices)(m)
+	return (*charDevices)(newMounts(logger, locator, devRoot, devices))
 }
 
 // Mounts returns the discovered mounts for the charDevices.

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/gds.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/gds.go
@@ -29,17 +29,17 @@ type gdsDeviceDiscoverer struct {
 }
 
 // NewGDSDiscoverer creates a discoverer for GPUDirect Storage devices and mounts.
-func NewGDSDiscoverer(logger logger.Interface, root string) (Discover, error) {
+func NewGDSDiscoverer(logger logger.Interface, driverRoot string, devRoot string) (Discover, error) {
 	devices := NewCharDeviceDiscoverer(
 		logger,
+		devRoot,
 		[]string{"/dev/nvidia-fs*"},
-		root,
 	)
 
 	udev := NewMounts(
 		logger,
-		lookup.NewDirectoryLocator(lookup.WithLogger(logger), lookup.WithRoot(root)),
-		root,
+		lookup.NewDirectoryLocator(lookup.WithLogger(logger), lookup.WithRoot(driverRoot)),
+		driverRoot,
 		[]string{"/run/udev"},
 	)
 
@@ -47,9 +47,9 @@ func NewGDSDiscoverer(logger logger.Interface, root string) (Discover, error) {
 		logger,
 		lookup.NewFileLocator(
 			lookup.WithLogger(logger),
-			lookup.WithRoot(root),
+			lookup.WithRoot(driverRoot),
 		),
-		root,
+		driverRoot,
 		[]string{"/etc/cufile.json"},
 	)
 

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/graphics.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/graphics.go
@@ -30,25 +30,20 @@ import (
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/lookup/cuda"
 )
 
-// NewGraphicsDiscoverer returns the discoverer for graphics tools such as Vulkan.
-func NewGraphicsDiscoverer(logger logger.Interface, devices image.VisibleDevices, driverRoot string, nvidiaCTKPath string) (Discover, error) {
-	mounts, err := NewGraphicsMountsDiscoverer(logger, driverRoot, nvidiaCTKPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create mounts discoverer: %v", err)
-	}
-
-	drmDeviceNodes, err := newDRMDeviceDiscoverer(logger, devices, driverRoot)
+// NewDRMNodesDiscoverer returns a discoverrer for the DRM device nodes associated with the specified visible devices.
+//
+// TODO: The logic for creating DRM devices should be consolidated between this
+// and the logic for generating CDI specs for a single device. This is only used
+// when applying OCI spec modifications to an incoming spec in "legacy" mode.
+func NewDRMNodesDiscoverer(logger logger.Interface, devices image.VisibleDevices, devRoot string, nvidiaCTKPath string) (Discover, error) {
+	drmDeviceNodes, err := newDRMDeviceDiscoverer(logger, devices, devRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DRM device discoverer: %v", err)
 	}
 
-	drmByPathSymlinks := newCreateDRMByPathSymlinks(logger, drmDeviceNodes, driverRoot, nvidiaCTKPath)
+	drmByPathSymlinks := newCreateDRMByPathSymlinks(logger, drmDeviceNodes, devRoot, nvidiaCTKPath)
 
-	discover := Merge(
-		Merge(drmDeviceNodes, drmByPathSymlinks),
-		mounts,
-	)
-
+	discover := Merge(drmDeviceNodes, drmByPathSymlinks)
 	return discover, nil
 }
 
@@ -99,16 +94,16 @@ type drmDevicesByPath struct {
 	None
 	logger        logger.Interface
 	nvidiaCTKPath string
-	driverRoot    string
+	devRoot       string
 	devicesFrom   Discover
 }
 
 // newCreateDRMByPathSymlinks creates a discoverer for a hook to create the by-path symlinks for DRM devices discovered by the specified devices discoverer
-func newCreateDRMByPathSymlinks(logger logger.Interface, devices Discover, driverRoot string, nvidiaCTKPath string) Discover {
+func newCreateDRMByPathSymlinks(logger logger.Interface, devices Discover, devRoot string, nvidiaCTKPath string) Discover {
 	d := drmDevicesByPath{
 		logger:        logger,
 		nvidiaCTKPath: nvidiaCTKPath,
-		driverRoot:    driverRoot,
+		devRoot:       devRoot,
 		devicesFrom:   devices,
 	}
 
@@ -155,7 +150,7 @@ func (d drmDevicesByPath) getSpecificLinkArgs(devices []Device) ([]string, error
 
 	linkLocator := lookup.NewFileLocator(
 		lookup.WithLogger(d.logger),
-		lookup.WithRoot(d.driverRoot),
+		lookup.WithRoot(d.devRoot),
 	)
 	candidates, err := linkLocator.Locate("/dev/dri/by-path/pci-*-*")
 	if err != nil {
@@ -181,21 +176,17 @@ func (d drmDevicesByPath) getSpecificLinkArgs(devices []Device) ([]string, error
 }
 
 // newDRMDeviceDiscoverer creates a discoverer for the DRM devices associated with the requested devices.
-func newDRMDeviceDiscoverer(logger logger.Interface, devices image.VisibleDevices, driverRoot string) (Discover, error) {
-	allDevices := NewDeviceDiscoverer(
+func newDRMDeviceDiscoverer(logger logger.Interface, devices image.VisibleDevices, devRoot string) (Discover, error) {
+	allDevices := NewCharDeviceDiscoverer(
 		logger,
-		lookup.NewCharDeviceLocator(
-			lookup.WithLogger(logger),
-			lookup.WithRoot(driverRoot),
-		),
-		driverRoot,
+		devRoot,
 		[]string{
 			"/dev/dri/card*",
 			"/dev/dri/renderD*",
 		},
 	)
 
-	filter, err := newDRMDeviceFilter(logger, devices, driverRoot)
+	filter, err := newDRMDeviceFilter(logger, devices, devRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct DRM device filter: %v", err)
 	}
@@ -211,8 +202,8 @@ func newDRMDeviceDiscoverer(logger logger.Interface, devices image.VisibleDevice
 }
 
 // newDRMDeviceFilter creates a filter that matches DRM devices nodes for the visible devices.
-func newDRMDeviceFilter(logger logger.Interface, devices image.VisibleDevices, driverRoot string) (Filter, error) {
-	gpuInformationPaths, err := proc.GetInformationFilePaths(driverRoot)
+func newDRMDeviceFilter(logger logger.Interface, devices image.VisibleDevices, devRoot string) (Filter, error) {
+	gpuInformationPaths, err := proc.GetInformationFilePaths(devRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read GPU information: %v", err)
 	}

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/mofed.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/mofed.go
@@ -19,14 +19,14 @@ package discover
 import "github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 
 // NewMOFEDDiscoverer creates a discoverer for MOFED devices.
-func NewMOFEDDiscoverer(logger logger.Interface, root string) (Discover, error) {
+func NewMOFEDDiscoverer(logger logger.Interface, devRoot string) (Discover, error) {
 	devices := NewCharDeviceDiscoverer(
 		logger,
+		devRoot,
 		[]string{
 			"/dev/infiniband/uverbs*",
 			"/dev/infiniband/rdma_cm",
 		},
-		root,
 	)
 
 	return devices, nil

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/lookup/file.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/lookup/file.go
@@ -148,6 +148,7 @@ var _ Locator = (*file)(nil)
 func (p file) Locate(pattern string) ([]string, error) {
 	var filenames []string
 
+	p.logger.Debugf("Locating %q in %v", pattern, p.prefixes)
 visit:
 	for _, prefix := range p.prefixes {
 		pathPattern := filepath.Join(prefix, pattern)

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/platform-support/tegra/csv.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/platform-support/tegra/csv.go
@@ -36,9 +36,8 @@ func (o tegraOptions) newDiscovererFromCSVFiles() (discover.Discover, error) {
 
 	targetsByType := getTargetsFromCSVFiles(o.logger, o.csvFiles)
 
-	devices := discover.NewDeviceDiscoverer(
+	devices := discover.NewCharDeviceDiscoverer(
 		o.logger,
-		lookup.NewCharDeviceLocator(lookup.WithLogger(o.logger), lookup.WithRoot(o.driverRoot)),
 		o.driverRoot,
 		targetsByType[csv.MountSpecDev],
 	)

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/platform-support/tegra/tegra.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/platform-support/tegra/tegra.go
@@ -29,6 +29,7 @@ type tegraOptions struct {
 	logger             logger.Interface
 	csvFiles           []string
 	driverRoot         string
+	devRoot            string
 	nvidiaCTKPath      string
 	librarySearchPaths []string
 	ignorePatterns     ignoreMountSpecPatterns
@@ -48,6 +49,10 @@ func New(opts ...Option) (discover.Discover, error) {
 	o := &tegraOptions{}
 	for _, opt := range opts {
 		opt(o)
+	}
+
+	if o.devRoot == "" {
+		o.devRoot = o.driverRoot
 	}
 
 	if o.symlinkLocator == nil {
@@ -107,6 +112,14 @@ func WithLogger(logger logger.Interface) Option {
 
 // WithDriverRoot sets the driver root for the discoverer.
 func WithDriverRoot(driverRoot string) Option {
+	return func(o *tegraOptions) {
+		o.driverRoot = driverRoot
+	}
+}
+
+// WithDevRoot sets the /dev root.
+// If this is unset, the driver root is assumed.
+func WithDevRoot(driverRoot string) Option {
 	return func(o *tegraOptions) {
 		o.driverRoot = driverRoot
 	}

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/common-nvml.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/common-nvml.go
@@ -20,22 +20,14 @@ import (
 	"fmt"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/discover"
-	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
-	"github.com/NVIDIA/nvidia-container-toolkit/internal/lookup"
-
-	"github.com/NVIDIA/go-nvlib/pkg/nvml"
 )
 
 // newCommonNVMLDiscoverer returns a discoverer for entities that are not associated with a specific CDI device.
 // This includes driver libraries and meta devices, for example.
-func newCommonNVMLDiscoverer(logger logger.Interface, driverRoot string, nvidiaCTKPath string, nvmllib nvml.Interface) (discover.Discover, error) {
-	metaDevices := discover.NewDeviceDiscoverer(
-		logger,
-		lookup.NewCharDeviceLocator(
-			lookup.WithLogger(logger),
-			lookup.WithRoot(driverRoot),
-		),
-		driverRoot,
+func (l *nvmllib) newCommonNVMLDiscoverer() (discover.Discover, error) {
+	metaDevices := discover.NewCharDeviceDiscoverer(
+		l.logger,
+		l.devRoot,
 		[]string{
 			"/dev/nvidia-modeset",
 			"/dev/nvidia-uvm-tools",
@@ -44,12 +36,12 @@ func newCommonNVMLDiscoverer(logger logger.Interface, driverRoot string, nvidiaC
 		},
 	)
 
-	graphicsMounts, err := discover.NewGraphicsMountsDiscoverer(logger, driverRoot, nvidiaCTKPath)
+	graphicsMounts, err := discover.NewGraphicsMountsDiscoverer(l.logger, l.driverRoot, l.nvidiaCTKPath)
 	if err != nil {
-		logger.Warningf("failed to create discoverer for graphics mounts: %v", err)
+		l.logger.Warningf("failed to create discoverer for graphics mounts: %v", err)
 	}
 
-	driverFiles, err := NewDriverDiscoverer(logger, driverRoot, nvidiaCTKPath, nvmllib)
+	driverFiles, err := NewDriverDiscoverer(l.logger, l.driverRoot, l.nvidiaCTKPath, l.nvmllib)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discoverer for driver files: %v", err)
 	}

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/device-wsl.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/device-wsl.go
@@ -26,11 +26,11 @@ const (
 )
 
 // newDXGDeviceDiscoverer returns a Discoverer for DXG devices under WSL2.
-func newDXGDeviceDiscoverer(logger logger.Interface, driverRoot string) discover.Discover {
+func newDXGDeviceDiscoverer(logger logger.Interface, devRoot string) discover.Discover {
 	deviceNodes := discover.NewCharDeviceDiscoverer(
 		logger,
+		devRoot,
 		[]string{dxgDeviceNode},
-		driverRoot,
 	)
 
 	return deviceNodes

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/gds.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/gds.go
@@ -33,7 +33,7 @@ var _ Interface = (*gdslib)(nil)
 
 // GetAllDeviceSpecs returns the device specs for all available devices.
 func (l *gdslib) GetAllDeviceSpecs() ([]specs.Device, error) {
-	discoverer, err := discover.NewGDSDiscoverer(l.logger, l.driverRoot)
+	discoverer, err := discover.NewGDSDiscoverer(l.logger, l.driverRoot, l.devRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GPUDirect Storage discoverer: %v", err)
 	}

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/lib-csv.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/lib-csv.go
@@ -42,6 +42,7 @@ func (l *csvlib) GetAllDeviceSpecs() ([]specs.Device, error) {
 	d, err := tegra.New(
 		tegra.WithLogger(l.logger),
 		tegra.WithDriverRoot(l.driverRoot),
+		tegra.WithDevRoot(l.devRoot),
 		tegra.WithNVIDIACTKPath(l.nvidiaCTKPath),
 		tegra.WithCSVFiles(l.csvFiles),
 		tegra.WithLibrarySearchPaths(l.librarySearchPaths...),

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/lib-nvml.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/lib-nvml.go
@@ -66,7 +66,7 @@ func (l *nvmllib) GetAllDeviceSpecs() ([]specs.Device, error) {
 
 // GetCommonEdits generates a CDI specification that can be used for ANY devices
 func (l *nvmllib) GetCommonEdits() (*cdi.ContainerEdits, error) {
-	common, err := newCommonNVMLDiscoverer(l.logger, l.driverRoot, l.nvidiaCTKPath, l.nvmllib)
+	common, err := l.newCommonNVMLDiscoverer()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discoverer for common entities: %v", err)
 	}

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/lib-wsl.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/lib-wsl.go
@@ -37,7 +37,7 @@ func (l *wsllib) GetSpec() (spec.Interface, error) {
 
 // GetAllDeviceSpecs returns the device specs for all available devices.
 func (l *wsllib) GetAllDeviceSpecs() ([]specs.Device, error) {
-	device := newDXGDeviceDiscoverer(l.logger, l.driverRoot)
+	device := newDXGDeviceDiscoverer(l.logger, l.devRoot)
 	deviceEdits, err := edits.FromDiscoverer(device)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create container edits for DXG device: %v", err)

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/lib.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/lib.go
@@ -44,6 +44,7 @@ type nvcdilib struct {
 	devicelib          device.Interface
 	deviceNamer        DeviceNamer
 	driverRoot         string
+	devRoot            string
 	nvidiaCTKPath      string
 	librarySearchPaths []string
 
@@ -75,6 +76,9 @@ func New(opts ...Option) (Interface, error) {
 	}
 	if l.driverRoot == "" {
 		l.driverRoot = "/"
+	}
+	if l.devRoot == "" {
+		l.devRoot = l.driverRoot
 	}
 	if l.nvidiaCTKPath == "" {
 		l.nvidiaCTKPath = "/usr/bin/nvidia-ctk"

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/management.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/management.go
@@ -109,6 +109,7 @@ type managementDiscoverer struct {
 func (m *managementlib) newManagementDeviceDiscoverer() (discover.Discover, error) {
 	deviceNodes := discover.NewCharDeviceDiscoverer(
 		m.logger,
+		m.devRoot,
 		[]string{
 			"/dev/nvidia*",
 			"/dev/nvidia-caps/nvidia-cap*",
@@ -117,12 +118,11 @@ func (m *managementlib) newManagementDeviceDiscoverer() (discover.Discover, erro
 			"/dev/nvidia-uvm",
 			"/dev/nvidiactl",
 		},
-		m.driverRoot,
 	)
 
 	deviceFolderPermissionHooks := newDeviceFolderPermissionHookDiscoverer(
 		m.logger,
-		m.driverRoot,
+		m.devRoot,
 		m.nvidiaCTKPath,
 		deviceNodes,
 	)

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/mig-device-nvml.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/mig-device-nvml.go
@@ -112,12 +112,12 @@ func newComputeInstanceDiscoverer(logger logger.Interface, driverRoot string, gp
 
 	deviceNodes := discover.NewCharDeviceDiscoverer(
 		logger,
+		driverRoot,
 		[]string{
 			parentPath,
 			giCapDevicePath,
 			ciCapDevicePath,
 		},
-		driverRoot,
 	)
 
 	return deviceNodes, nil

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/options.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/options.go
@@ -47,6 +47,13 @@ func WithDriverRoot(root string) Option {
 	}
 }
 
+// WithDevRoot sets the root where /dev is located.
+func WithDevRoot(root string) Option {
+	return func(l *nvcdilib) {
+		l.devRoot = root
+	}
+}
+
 // WithLogger sets the logger for the library
 func WithLogger(logger logger.Interface) Option {
 	return func(l *nvcdilib) {

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/workarounds-device-folder-permissions.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/workarounds-device-folder-permissions.go
@@ -26,7 +26,7 @@ import (
 
 type deviceFolderPermissions struct {
 	logger        logger.Interface
-	driverRoot    string
+	devRoot       string
 	nvidiaCTKPath string
 	devices       discover.Discover
 }
@@ -39,10 +39,10 @@ var _ discover.Discover = (*deviceFolderPermissions)(nil)
 // The nested devices that are applicable to the NVIDIA GPU devices are:
 //   - DRM devices at /dev/dri/*
 //   - NVIDIA Caps devices at /dev/nvidia-caps/*
-func newDeviceFolderPermissionHookDiscoverer(logger logger.Interface, driverRoot string, nvidiaCTKPath string, devices discover.Discover) discover.Discover {
+func newDeviceFolderPermissionHookDiscoverer(logger logger.Interface, devRoot string, nvidiaCTKPath string, devices discover.Discover) discover.Discover {
 	d := &deviceFolderPermissions{
 		logger:        logger,
-		driverRoot:    driverRoot,
+		devRoot:       devRoot,
 		nvidiaCTKPath: nvidiaCTKPath,
 		devices:       devices,
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -7,7 +7,7 @@ github.com/NVIDIA/go-nvlib/pkg/nvml
 ## explicit; go 1.15
 github.com/NVIDIA/go-nvml/pkg/dl
 github.com/NVIDIA/go-nvml/pkg/nvml
-# github.com/NVIDIA/nvidia-container-toolkit v1.14.4-0.20231120112525-f6e3593a726a
+# github.com/NVIDIA/nvidia-container-toolkit v1.14.4-0.20231120225202-039d7fd32429
 ## explicit; go 1.20
 github.com/NVIDIA/nvidia-container-toolkit/internal/config/image
 github.com/NVIDIA/nvidia-container-toolkit/internal/discover


### PR DESCRIPTION
These changes allow the DRA driver to run on GKE (which supports enabling alpha features).

They include:
* Scripting to set up a GKE cluster
* Demos showing device selection based on constraints
* Updates to the CDI spec generation to handle the GKE node configuration.

Running the included demo with the image `ghcr.io/nvidia/k8s-dra-driver:e4a95c14-ubuntu20.04`:
```
 kubectl get nodeallocationstates.nas.gpu.resource.nvidia.com -A -o=json \
        | jq -r '.items[]
             | select(.spec.allocatedClaims)
             | "\(.metadata.name):",
             (.spec.allocatedClaims[])'

gke-k8s-dra-driver-cluster-pool-1-82ea8e4c-02x4:
{
  "claimInfo": {
    "name": "inference-pod-gpu",
    "namespace": "kubecon-demo",
    "uid": "39f74f77-98c4-44bc-9c46-125e5700a60a"
  },
  "gpu": {
    "devices": [
      {
        "uuid": "GPU-679f75dd-b95c-ef89-d691-f3c4f523d43b"
      }
    ]
  }
}
gke-k8s-dra-driver-cluster-pool-2-2afcfde8-86sd:
{
  "claimInfo": {
    "name": "training-pod-gpu",
    "namespace": "kubecon-demo",
    "uid": "5ca7c648-ec6a-4228-ac05-6af75dc36d4c"
  },
  "gpu": {
    "devices": [
      {
        "uuid": "GPU-66e80786-6056-af90-1aaa-10aebff0155a"
      }
    ]
  }
}
```
and
```
➜  k8s-dra-driver git:(dra-on-gke) ✗ kubectl logs -n kubecon-demo inference-pod
GPU 0: Tesla T4 (UUID: GPU-679f75dd-b95c-ef89-d691-f3c4f523d43b)
➜  k8s-dra-driver git:(dra-on-gke) ✗ kubectl logs -n kubecon-demo training-pod
GPU 0: Tesla V100-SXM2-16GB (UUID: GPU-66e80786-6056-af90-1aaa-10aebff0155a)
```