### PR TITLE
Update DRA driver image in demo

### DIFF
--- a/demo/clusters/gke/install-dra-driver.sh
+++ b/demo/clusters/gke/install-dra-driver.sh
@@ -25,9 +25,9 @@ function from_versions_mk() {
 }
 DRIVER_NAME=$(from_versions_mk "DRIVER_NAME")
 
-: ${IMAGE_REGISTRY:=registry.gitlab.com/nvidia/cloud-native/k8s-dra-driver/staging}
+: ${IMAGE_REGISTRY:=ghcr.io/nvidia}
 : ${IMAGE_NAME:=${DRIVER_NAME}}
-: ${IMAGE_TAG:=530b16c-ubuntu20.04}
+: ${IMAGE_TAG:=9323da2d-ubuntu20.04}
 
 helm upgrade -i --create-namespace --namespace nvidia nvidia-dra-driver ${PROJECT_DIR}/deployments/helm/k8s-dra-driver \
   --set image.repository=${IMAGE_REGISTRY}/${IMAGE_NAME} \


### PR DESCRIPTION
Switch to the ghcr.io/nvidia/k8s-dra-driver:9323da2d-ubuntu20.04 image for GKE-based demos.