### PR TITLE
Let kublet plugin run privileged on OpenShift

### DIFF
--- a/deployments/helm/k8s-dra-driver/templates/openshiftprivilegedrolebinging.yaml
+++ b/deployments/helm/k8s-dra-driver/templates/openshiftprivilegedrolebinging.yaml
@@ -1,0 +1,17 @@
+# Apply only when running on OpenShift to let the kublet plugin run privileged
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "k8s-dra-driver.fullname" . }}-openshift-privileged-role-binding
+  namespace: {{ include "k8s-dra-driver.namespace" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "k8s-dra-driver.serviceAccountName" . }}
+  namespace: {{ include "k8s-dra-driver.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}


### PR DESCRIPTION
On OpenShift, the kublet plugin container won't run without applying the right
security settings that let it run privileged. We solve this by binding the privileged
security context constraints (SCC) role to the DRA driver's service account.

This is done only when the target system has the OpenShift SCC capability in order
to minimise the impact on non-OpenShift platforms.