### PR TITLE
Update ci defs

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 NVIDIA CORPORATION
+# Copyright 2023-2024 NVIDIA CORPORATION
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,28 +29,45 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-
+      name: Checkout code
+    - name: Get Golang version
+      id: vars
+      run: |
+        GOLANG_VERSION=$( grep "GOLANG_VERSION ?=" versions.mk )
+        echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION ?= }" >> $GITHUB_ENV
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GOLANG_VERSION }}
     - name: Lint
       uses: golangci/golangci-lint-action@v4
       with:
         version: latest
         args: -v --timeout 5m
         skip-cache: true
+    - name: Check golang modules
+      run: make check-vendor
   test:
       name: Unit test
       runs-on: ubuntu-latest
       steps:
         - name: Checkout code
           uses: actions/checkout@v4
+        - name: Get Golang version
+          id: vars
+          run: |
+            GOLANG_VERSION=$( grep "GOLANG_VERSION ?=" versions.mk )
+            echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION ?= }" >> $GITHUB_ENV
         - name: Install Go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.20'
+            go-version: ${{ env.GOLANG_VERSION }}
         - run: make test
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      name: Checkout code
 
     - name: Build
       run: make docker-build

--- a/cmd/nvidia-dra-plugin/driver.go
+++ b/cmd/nvidia-dra-plugin/driver.go
@@ -198,12 +198,12 @@ func (d *driver) CleanupStaleStateContinuously(ctx context.Context) {
 	for {
 		resourceVersion, err := d.cleanupStaleStateOnce(ctx)
 		if err != nil {
-			klog.Errorf("Error cleaning up stale claim state: %w", err)
+			klog.Errorf("Error cleaning up stale claim state: %v", err)
 		}
 
 		err = d.cleanupStaleStateContinuously(ctx, resourceVersion, err)
 		if err != nil {
-			klog.Errorf("Error cleaning up stale claim state: %w", err)
+			klog.Errorf("Error cleaning up stale claim state: %v", err)
 			time.Sleep(CleanupTimeoutSecondsOnError * time.Second)
 		}
 	}
@@ -279,7 +279,7 @@ func (d *driver) cleanupStaleState(ctx context.Context, nas *nascrd.NodeAllocati
 	go func() {
 		count := 0
 		for err := range caErrors {
-			klog.Errorf("Error cleaning up claim allocations: %w", err)
+			klog.Errorf("Error cleaning up claim allocations: %v", err)
 			count++
 		}
 		errorCounts <- count
@@ -290,7 +290,7 @@ func (d *driver) cleanupStaleState(ctx context.Context, nas *nascrd.NodeAllocati
 	go func() {
 		count := 0
 		for err := range cdiErrors {
-			klog.Errorf("Error cleaning up CDI files: %w", err)
+			klog.Errorf("Error cleaning up CDI files: %v", err)
 			count++
 		}
 		errorCounts <- count
@@ -301,7 +301,7 @@ func (d *driver) cleanupStaleState(ctx context.Context, nas *nascrd.NodeAllocati
 	go func() {
 		count := 0
 		for err := range mpsErrors {
-			klog.Errorf("Error cleaning up MPS control daemon artifacts: %w", err)
+			klog.Errorf("Error cleaning up MPS control daemon artifacts: %v", err)
 			count++
 		}
 		errorCounts <- count

--- a/cmd/nvidia-dra-plugin/main.go
+++ b/cmd/nvidia-dra-plugin/main.go
@@ -191,7 +191,7 @@ func StartPlugin(ctx context.Context, config *Config) error {
 
 	err = driver.Shutdown(ctx)
 	if err != nil {
-		klog.Errorf("Unable to cleanly shutdown driver: %w", err)
+		klog.Errorf("Unable to cleanly shutdown driver: %v", err)
 	}
 
 	return nil

--- a/deployments/container/Dockerfile.ubi8
+++ b/deployments/container/Dockerfile.ubi8
@@ -16,7 +16,28 @@ ARG GOLANG_VERSION=1.20.4
 ARG CUDA_IMAGE=cuda
 ARG CUDA_VERSION=11.8.0
 ARG BASE_DIST=ubi8
-FROM golang:${GOLANG_VERSION} as build
+FROM nvidia/cuda:${CUDA_VERSION}-base-${BASE_DIST} as build
+
+RUN yum install -y \
+    wget make git gcc \
+     && \
+    rm -rf /var/cache/yum/*
+
+ARG GOLANG_VERSION=x.x.x
+RUN set -eux; \
+    \
+    arch="$(uname -m)"; \
+    case "${arch##*-}" in \
+        x86_64 | amd64) ARCH='amd64' ;; \
+        ppc64el | ppc64le) ARCH='ppc64le' ;; \
+        aarch64 | arm64) ARCH='arm64' ;; \
+        *) echo "unsupported architecture" ; exit 1 ;; \
+    esac; \
+    wget -nv -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
+    | tar -C /usr/local -xz
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 WORKDIR /build
 COPY . .

--- a/deployments/container/Dockerfile.ubuntu
+++ b/deployments/container/Dockerfile.ubuntu
@@ -16,7 +16,28 @@ ARG GOLANG_VERSION=1.20.4
 ARG CUDA_IMAGE=cuda
 ARG CUDA_VERSION=11.8.0
 ARG BASE_DIST=ubuntu20.04
-FROM golang:${GOLANG_VERSION} as build
+FROM nvidia/cuda:${CUDA_VERSION}-base-${BASE_DIST} as build
+
+RUN apt-get update && \
+    apt-get install -y wget make git gcc \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG GOLANG_VERSION=x.x.x
+RUN set -eux; \
+    \
+    arch="$(uname -m)"; \
+    case "${arch##*-}" in \
+        x86_64 | amd64) ARCH='amd64' ;; \
+        ppc64el | ppc64le) ARCH='ppc64le' ;; \
+        aarch64 | arm64) ARCH='arm64' ;; \
+        *) echo "unsupported architecture" ; exit 1 ;; \
+    esac; \
+    wget -nv -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
+    | tar -C /usr/local -xz
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 WORKDIR /build
 COPY . .

--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) YEAR, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This makes the following changes:
* Add `check-vendor` make target
* Set boilerplate year to 2023 to remove diffs when running `make generate`
* Use cuda base images to build applications to address possible glibc version issues. 
* Fix errors in using `%w` in `klog.Errorf`