### PR TITLE
Add hostPID to MPS daemon template

### DIFF
--- a/templates/mps-control-daemon.tmpl.yaml
+++ b/templates/mps-control-daemon.tmpl.yaml
@@ -17,6 +17,7 @@ spec:
         app: {{ .MpsControlDaemonName }}
     spec:
       nodeName: {{ .NodeName }}
+      hostPID: true
       containers:
       - name: mps-control-daemon
         image: ubuntu:22.04


### PR DESCRIPTION
Without this, the MPS server was not able to find it's own PID via /proc/self and was failing to start. It's unclear why this wasn't needed previously, but it makes sense why adding hostPID would solve this.