### PR TITLE
feat: add health check and liveness probe

### DIFF
--- a/deployments/helm/k8s-dra-driver/templates/controller.yaml
+++ b/deployments/helm/k8s-dra-driver/templates/controller.yaml
@@ -44,6 +44,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        livenessProbe:
+            httpGet:
+              - path: /healthz
+                port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+        ports:
+          - containerPort: 8081
+            name: healthz
+            protocol: TCP
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
By making a new endpoint and adding the liveness probe port with port of container to the helm chart of controller, it can restart when it is unhealthy.