### PR TITLE
Update all demos so that their PID 1 processes explicitly catch SIGTERM

### DIFF
--- a/demo/specs/quickstart/gpu-test1.yaml
+++ b/demo/specs/quickstart/gpu-test1.yaml
@@ -33,7 +33,7 @@ spec:
   - name: ctr
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["nvidia-smi -L; sleep 9999"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
     resources:
       claims:
       - name: gpu
@@ -54,7 +54,7 @@ spec:
   - name: ctr
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["nvidia-smi -L; sleep 9999"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
     resources:
       claims:
       - name: gpu

--- a/demo/specs/quickstart/gpu-test2.yaml
+++ b/demo/specs/quickstart/gpu-test2.yaml
@@ -31,14 +31,14 @@ spec:
   - name: ctr0
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["nvidia-smi -L; sleep 9999"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
     resources:
       claims:
       - name: shared-gpu
   - name: ctr1
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["nvidia-smi -L; sleep 9999"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
     resources:
       claims:
       - name: shared-gpu

--- a/demo/specs/quickstart/gpu-test3.yaml
+++ b/demo/specs/quickstart/gpu-test3.yaml
@@ -32,7 +32,7 @@ spec:
   - name: ctr
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["nvidia-smi -L; sleep 9999"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
     resources:
       claims:
       - name: shared-gpu
@@ -53,7 +53,7 @@ spec:
   - name: ctr
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["nvidia-smi -L; sleep 9999"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
     resources:
       claims:
       - name: shared-gpu

--- a/demo/specs/quickstart/gpu-test4.yaml
+++ b/demo/specs/quickstart/gpu-test4.yaml
@@ -68,7 +68,7 @@ spec:
       - name: ctr0
         image: ubuntu:22.04
         command: ["bash", "-c"]
-        args: ["nvidia-smi -L; sleep 9999"]
+        args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
         resources:
           claims:
           - name: mig-devices
@@ -76,7 +76,7 @@ spec:
       - name: ctr1
         image: ubuntu:22.04
         command: ["bash", "-c"]
-        args: ["nvidia-smi -L; sleep 9999"]
+        args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
         resources:
           claims:
           - name: mig-devices
@@ -84,7 +84,7 @@ spec:
       - name: ctr2
         image: ubuntu:22.04
         command: ["bash", "-c"]
-        args: ["nvidia-smi -L; sleep 9999"]
+        args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
         resources:
           claims:
           - name: mig-devices
@@ -92,7 +92,7 @@ spec:
       - name: ctr3
         image: ubuntu:22.04
         command: ["bash", "-c"]
-        args: ["nvidia-smi -L; sleep 9999"]
+        args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
         resources:
           claims:
           - name: mig-devices

--- a/demo/specs/quickstart/gpu-test5.yaml
+++ b/demo/specs/quickstart/gpu-test5.yaml
@@ -54,28 +54,32 @@ spec:
   containers:
   - name: ts-ctr0
     image: nvcr.io/nvidia/k8s/cuda-sample:nbody-cuda11.6.0-ubuntu18.04
-    args: ["--benchmark", "--numbodies=4226000"]
+    command: ["bash", "-c"]
+    args: ["trap 'exit 0' TERM; /tmp/sample --benchmark --numbodies=4226000 & wait"]
     resources:
       claims:
       - name: shared-gpus
         request: ts-gpu
   - name: ts-ctr1
     image: nvcr.io/nvidia/k8s/cuda-sample:nbody-cuda11.6.0-ubuntu18.04
-    args: ["--benchmark", "--numbodies=4226000"]
+    command: ["bash", "-c"]
+    args: ["trap 'exit 0' TERM; /tmp/sample --benchmark --numbodies=4226000 & wait"]
     resources:
       claims:
       - name: shared-gpus
         request: ts-gpu
   - name: mps-ctr0
     image: nvcr.io/nvidia/k8s/cuda-sample:nbody-cuda11.6.0-ubuntu18.04
-    args: ["--benchmark", "--numbodies=4226000"]
+    command: ["bash", "-c"]
+    args: ["trap 'exit 0' TERM; /tmp/sample --benchmark --numbodies=4226000 & wait"]
     resources:
       claims:
       - name: shared-gpus
         request: mps-gpu
   - name: mps-ctr1
     image: nvcr.io/nvidia/k8s/cuda-sample:nbody-cuda11.6.0-ubuntu18.04
-    args: ["--benchmark", "--numbodies=4226000"]
+    command: ["bash", "-c"]
+    args: ["trap 'exit 0' TERM; /tmp/sample --benchmark --numbodies=4226000 & wait"]
     resources:
       claims:
       - name: shared-gpus

--- a/demo/specs/quickstart/gpu-test6.yaml
+++ b/demo/specs/quickstart/gpu-test6.yaml
@@ -72,7 +72,7 @@ spec:
       - name: ctr
         image: ubuntu:22.04
         command: ["bash", "-c"]
-        args: ["nvidia-smi -L; sleep 9999"]
+        args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
         resources:
           claims:
           - name: a100

--- a/demo/specs/selectors/pods.yaml
+++ b/demo/specs/selectors/pods.yaml
@@ -15,7 +15,7 @@ spec:
   - name: ctr
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["nvidia-smi -L; sleep 9999"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
     resources:
       claims:
       - name: gpu
@@ -41,7 +41,7 @@ spec:
   - name: ctr
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["nvidia-smi -L; sleep 9999"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
     resources:
       claims:
       - name: gpu


### PR DESCRIPTION
Without this, they end up waiting up to 30s on deletion since they are unable to shutdown gracefully on their own.