### PR TITLE
chore(docs): update README docs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,14 @@ We now install the NVIDIA GPU DRA driver:
 ./demo/clusters/kind/install-dra-driver.sh
 ```
 
-This should show two pods running in the `nvidia-dra-driver` namespace:
+This should show two pods running in the `nvidia` namespace:
 ```console
-kubectl get pods -n nvidia-dra-driver
+kubectl get pods -n nvidia
 ```
 ```
-NAME                                         READY   STATUS    RESTARTS   AGE
-nvidia-k8s-dra-driver-kubelet-plugin-t5qgz   1/1     Running   0          44s
+NAME                                                           READY   STATUS    RESTARTS   AGE
+nvidia-dra-driver-k8s-dra-driver-controller-7d47546f78-62qlh   1/1     Running   0          43s
+nvidia-dra-driver-k8s-dra-driver-kubelet-plugin-4lkc4          1/1     Running   0          43s
 ```
 
 ### Run the examples by following the steps in the demo script


### PR DESCRIPTION
Use README.md to install, and find that some places need to be updated. 
now, we have plugins and contoller components.

```bash
...
+ kubectl label node -l node-role.x-k8s.io/worker --overwrite nvidia.com/gpu.present=true
node/k8s-dra-driver-cluster-worker labeled
+ deviceClasses=gpu,mig,imex
+ helm upgrade -i --create-namespace --namespace nvidia nvidia-dra-driver /home/ubuntu/k8s-dra-driver/deployments/helm/k8s-dra-driver --set 'deviceClasses={gpu,mig,imex}' --wait
Release "nvidia-dra-driver" does not exist. Installing it now.
NAME: nvidia-dra-driver
LAST DEPLOYED: Sun Dec  8 15:28:05 2024
NAMESPACE: nvidia
STATUS: deployed
REVISION: 1
TEST SUITE: None
+ set +x
Driver installation complete:
NAME                                                           READY   STATUS    RESTARTS   AGE
nvidia-dra-driver-k8s-dra-driver-controller-7d47546f78-62qlh   1/1     Running   0          2s
nvidia-dra-driver-k8s-dra-driver-kubelet-plugin-4lkc4          1/1     Running   0          2s
root@VM-0-17-ubuntu:/home/ubuntu/k8s-dra-driver# kubectl get pods -n nvidia-dra-driver
No resources found in nvidia-dra-driver namespace.
root@VM-0-17-ubuntu:/home/ubuntu/k8s-dra-driver# kubectl get pods -n nvidia
NAME                                                           READY   STATUS    RESTARTS   AGE
nvidia-dra-driver-k8s-dra-driver-controller-7d47546f78-62qlh   1/1     Running   0          43s
nvidia-dra-driver-k8s-dra-driver-kubelet-plugin-4lkc4          1/1     Running   0          43s
```