### PR TITLE
Limit cluster access

### DIFF
--- a/deployments/helm/k8s-dra-driver/templates/clusterrole.yaml
+++ b/deployments/helm/k8s-dra-driver/templates/clusterrole.yaml
@@ -5,10 +5,15 @@ metadata:
   name: {{ include "k8s-dra-driver.fullname" . }}-role
   namespace: {{ include "k8s-dra-driver.namespace" . }}
 rules:
-- apiGroups:
-  - ""
-  - apps
-  - resource.k8s.io
-  - gpu.nvidia.com
-  resources: ["*"]
-  verbs: ["*"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims"]
+  verbs: ["get"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/status"]
+  verbs: ["update"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceslices"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/deployments/helm/k8s-dra-driver/templates/validatingadmissionpolicy.yaml
+++ b/deployments/helm/k8s-dra-driver/templates/validatingadmissionpolicy.yaml
@@ -21,11 +21,13 @@ spec:
   - name: objectNodeName
     expression: >-
       (request.operation == "DELETE" ? oldObject : object).spec.?nodeName.orValue("")
+  - name: nodeSelectorValue
+    expression: >-
+      (request.operation == "DELETE" ? oldObject : object).spec.nodeSelector.nodeSelectorTerms[0].matchExpressions[0].values[0].orValue("")
   validations:
   - expression: variables.userNodeName != ""
     message: >-
       no node association found for user, this user must run in a pod on a node and ServiceAccountTokenPodNodeInfo must be enabled
-  - expression: variables.userNodeName == variables.objectNodeName
+  - expression: variables.userNodeName == variables.objectNodeName || variables.nodeSelectorValue != ""
     messageExpression: >-
-      "this user running on node '"+variables.userNodeName+"' may not modify " +
-      (variables.objectNodeName == "" ?"cluster resourceslices" : "resourceslices on node '"+variables.objectNodeName+"'")
+      "this user running on node '"+variables.userNodeName+"' may not modify cluster or node resourceslices"

--- a/deployments/helm/k8s-dra-driver/templates/validatingadmissionpolicy.yaml
+++ b/deployments/helm/k8s-dra-driver/templates/validatingadmissionpolicy.yaml
@@ -1,0 +1,31 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: resourceslices-policy-{{ include "k8s-dra-driver.fullname" . }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["resource.k8s.io"]
+      apiVersions: ["v1beta1"]
+      operations:  ["CREATE", "UPDATE", "DELETE"]
+      resources:   ["resourceslices"]
+  matchConditions:
+  - name: isRestrictedUser
+    expression: >-
+      request.userInfo.username == "system:serviceaccount:{{ include "k8s-dra-driver.namespace" . }}:{{ include "k8s-dra-driver.serviceAccountName" . }}"
+  variables:
+  - name: userNodeName
+    expression: >-
+      request.userInfo.extra[?'authentication.kubernetes.io/node-name'][0].orValue('')
+  - name: objectNodeName
+    expression: >-
+      (request.operation == "DELETE" ? oldObject : object).spec.?nodeName.orValue("")
+  validations:
+  - expression: variables.userNodeName != ""
+    message: >-
+      no node association found for user, this user must run in a pod on a node and ServiceAccountTokenPodNodeInfo must be enabled
+  - expression: variables.userNodeName == variables.objectNodeName
+    messageExpression: >-
+      "this user running on node '"+variables.userNodeName+"' may not modify " +
+      (variables.objectNodeName == "" ?"cluster resourceslices" : "resourceslices on node '"+variables.objectNodeName+"'")

--- a/deployments/helm/k8s-dra-driver/templates/validatingadmissionpolicybinding.yaml
+++ b/deployments/helm/k8s-dra-driver/templates/validatingadmissionpolicybinding.yaml
@@ -1,0 +1,8 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: resourceslices-policy-{{ include "k8s-dra-driver.fullname" . }}
+spec:
+  policyName: resourceslices-policy-{{ include "k8s-dra-driver.fullname" . }}
+  validationActions: [Deny]
+  # All ResourceSlices are matched.


### PR DESCRIPTION
I am not sure if validatingadmissionpolicy is required right now. And we may add more rules like only allow updates when driver is gpu.nvidia.com, something like 

object.spec.driver == 'gpu.nvidia.com' 

I did a quick test with the original implementation done here https://github.com/kubernetes/kubernetes/blob/4aeaf1e99e82da8334c0d6dddd848a194cd44b4f/test/e2e/dra/test-driver/deploy/example/plugin-permissions.yaml#L38

```
1 resourceslicecontroller.go:313] "processing ResourceSlice objects" err="update resource slice: resourceslices.resource.k8s.io \"nvidia-dra-driver-k8s-dra-driver-controller-7f78c745f6-ngnjlfwt\" is forbidden: ValidatingAdmissionPolicy 'resourceslices-policy-nvidia-dra-driver-k8s-dra-driver' with binding 'resourceslices-policy-nvidia-dra-driver-k8s-dra-driver' denied request: this user running on node 'xxxxxxxxx' may not modify cluster resourceslices" logger="UnhandledError"
```