### PR TITLE
Add rbac for deployment

### DIFF
--- a/deployments/helm/k8s-dra-driver/templates/clusterrole.yaml
+++ b/deployments/helm/k8s-dra-driver/templates/clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "k8s-dra-driver.fullname" . }}-role
+  name: {{ include "k8s-dra-driver.fullname" . }}-cluster-role
   namespace: {{ include "k8s-dra-driver.namespace" . }}
 rules:
 - apiGroups: ["resource.k8s.io"]

--- a/deployments/helm/k8s-dra-driver/templates/role.yaml
+++ b/deployments/helm/k8s-dra-driver/templates/role.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "k8s-dra-driver.fullname" . }}-role
+  namespace: {{ include "k8s-dra-driver.namespace" . }}
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/deployments/helm/k8s-dra-driver/templates/role.yaml
+++ b/deployments/helm/k8s-dra-driver/templates/role.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ include "k8s-dra-driver.fullname" . }}-role
   namespace: {{ include "k8s-dra-driver.namespace" . }}
 rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: ["apps"]
   resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/deployments/helm/k8s-dra-driver/templates/rolebinding.yaml
+++ b/deployments/helm/k8s-dra-driver/templates/rolebinding.yaml
@@ -1,14 +1,14 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: {{ include "k8s-dra-driver.fullname" . }}-cluster-role-binding
+  name: {{ include "k8s-dra-driver.fullname" . }}-role-binding
   namespace: {{ include "k8s-dra-driver.namespace" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "k8s-dra-driver.serviceAccountName" . }}
   namespace: {{ include "k8s-dra-driver.namespace" . }}
 roleRef:
-  kind: ClusterRole
-  name: {{ include "k8s-dra-driver.fullname" . }}-cluster-role
+  kind: Role
+  name: {{ include "k8s-dra-driver.fullname" . }}-role
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
To fix https://github.com/NVIDIA/k8s-dra-driver/issues/229 cc @dekonnection

```
$ kubectl auth can-i get deployments --as=system:serviceaccount:nvidia-dra-driver:nvidia-dra-driver-k8s-dra-driver-service-account -n nvidia-dra-driver
yes
```